### PR TITLE
Inline trivial methods

### DIFF
--- a/src/buffer/mod.rs
+++ b/src/buffer/mod.rs
@@ -17,7 +17,9 @@ pub enum BufImpl {
 }
 
 macro_rules! forward_method {
-    (pub fn $fnname:ident(&self $($args:tt)*) [$($passargs:tt)*] $(-> $ret:ty)*) => {
+    ($(#[$m:meta])*
+     pub fn $fnname:ident(&self $($args:tt)*) [$($passargs:tt)*] $(-> $ret:ty)*) => {
+        $(#[$m])*
         pub fn $fnname(&self $($args)*) $(-> $ret)* {
             match *self {
                 BufImpl::Std(ref buf) => buf.$fnname($($passargs)*),
@@ -27,7 +29,9 @@ macro_rules! forward_method {
         }
     };
 
-    (pub fn $fnname:ident(&mut self $($args:tt)*) [$($passargs:tt)*] $(-> $ret:ty)*) => {
+    ($(#[$m:meta])*
+     pub fn $fnname:ident(&mut self $($args:tt)*) [$($passargs:tt)*] $(-> $ret:ty)*) => {
+        $(#[$m])*
         pub fn $fnname(&mut self $($args)*) $(-> $ret)* {
             match *self {
                 BufImpl::Std(ref mut buf) => buf.$fnname($($passargs)*),
@@ -37,7 +41,9 @@ macro_rules! forward_method {
         }
     };
 
-    (pub unsafe fn $fnname:ident(&self $($args:tt)*) [$($passargs:tt)*] $(-> $ret:ty)*) => {
+    ($(#[$m:meta])*
+     pub unsafe fn $fnname:ident(&self $($args:tt)*) [$($passargs:tt)*] $(-> $ret:ty)*) => {
+        $(#[$m])*
         pub unsafe fn $fnname(&self $($args)*) $(-> $ret)* {
             match *self {
                 BufImpl::Std(ref buf) => buf.$fnname($($passargs)*),
@@ -47,7 +53,9 @@ macro_rules! forward_method {
         }
     };
 
-    (pub unsafe fn $fnname:ident(&mut self $($args:tt)*) [$($passargs:tt)*] $(-> $ret:ty)*) => {
+    ($(#[$m:meta])*
+     pub unsafe fn $fnname:ident(&mut self $($args:tt)*) [$($passargs:tt)*] $(-> $ret:ty)*) => {
+        $(#[$m])*
         pub unsafe fn $fnname(&mut self $($args)*) $(-> $ret)* {
             match *self {
                 BufImpl::Std(ref mut buf) => buf.$fnname($($passargs)*),
@@ -59,9 +67,10 @@ macro_rules! forward_method {
 }
 
 macro_rules! forward_methods {
-    ($($($qualifiers:ident)+ ($($args:tt)*) [$($passargs:tt)*] $(-> $ret:ty)*);+;) => (
+    ($($(#[$m:meta])*
+     $($qualifiers:ident)+ ($($args:tt)*) [$($passargs:tt)*] $(-> $ret:ty)*);+;) => (
         $(forward_method! {
-            $($qualifiers)+ ($($args)*) [$($passargs)*] $(-> $ret)*
+            $(#[$m])* $($qualifiers)+ ($($args)*) [$($passargs)*] $(-> $ret)*
         })*
     )
 }
@@ -95,6 +104,7 @@ impl BufImpl {
 
         pub fn make_room(&mut self)[];
 
+        #[inline]
         pub fn buf(&self)[] -> &[u8];
 
         pub fn buf_mut(&mut self)[] -> &mut [u8];

--- a/src/buffer/slice_deque_buf.rs
+++ b/src/buffer/slice_deque_buf.rs
@@ -46,6 +46,7 @@ impl SliceDequeBuf {
     /// This method is a no-op.
     pub fn make_room(&mut self) {}
 
+    #[inline]
     pub fn buf(&self) -> &[u8] {
         &self.deque
     }

--- a/src/buffer/std_buf.rs
+++ b/src/buffer/std_buf.rs
@@ -72,6 +72,7 @@ impl StdBuf {
         self.end = len;
     }
 
+    #[inline]
     pub fn buf(&self) -> &[u8] {
         unsafe { &self.buf.as_slice()[self.pos..self.end] }
     }
@@ -151,6 +152,7 @@ mod impl_ {
             false
         }
 
+        #[inline]
         pub unsafe fn as_slice(&self) -> &[u8] {
             &self.buf
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -285,6 +285,7 @@ impl<R, P> BufReader<R, P> {
     /// Get the section of the buffer containing valid data; may be empty.
     ///
     /// Call `.consume()` to remove bytes from the beginning of this section.
+    #[inline]
     pub fn buffer(&self) -> &[u8] {
         self.buf.buf()
     }
@@ -1011,6 +1012,7 @@ impl Buffer {
     /// Get an immutable slice of the available bytes in this buffer.
     ///
     /// Call `.consume()` to remove bytes from the beginning of this slice.
+    #[inline]
     pub fn buf(&self) -> &[u8] {
         self.buf.buf()
     }
@@ -1215,6 +1217,7 @@ impl<R> Unbuffer<R> {
     }
 
     /// Get a slice over the available bytes in the buffer.
+    #[inline]
     pub fn buf(&self) -> &[u8] {
         self.buf.as_ref().map_or(&[], Buffer::buf)
     }


### PR DESCRIPTION
I have been depending on `buf-redux` in the [seq_io](https://github.com/markschl/seq_io) project for some time now, and am switching to `buffer-redux` since `buf-redux` is unmaintained. While doing this, I would like to take the opportunity and propose the inlining of some trivial methods. This PR contains a commit, which adds `#[inline]` to `BufReader::buffer()` and the `Buffer::buf()` (and other methods they depend on). `seq_io` needs to frequently access the buffer and inlining thus leads to a significant performance improvement. In my tests, run times become equivalent to those when compiling with LTO enabled. This change would thus be really useful for `seq_io` and its users.

It would probably make sense to add `#[inline]` to other trivial methods in order to be consistent. In case you agree with this work, I can try to come up with a selection of methods where inlining might make sense.