### PR TITLE
chore: switch from slice-deque to its fork slice-ring-buffer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,9 @@ edition = "2021"
 memchr = "2.0"
 
 # `slice_deque` is only supported on platforms with virtual memory
-[target.'cfg(any(unix, windows))'.dependencies.slice-deque]
+[target.'cfg(any(unix, windows))'.dependencies.slice-ring-buffer]
 version = "0.3"
 optional = true
 
 [features]
-default = ["slice-deque"]
+default = ["slice-ring-buffer"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,4 +19,5 @@ version = "0.3"
 optional = true
 
 [features]
-default = ["slice-ring-buffer"]
+default = ["slice-deque"]
+slice-deque = ["dep:slice-ring-buffer"]

--- a/src/buffer/slice_deque_buf.rs
+++ b/src/buffer/slice_deque_buf.rs
@@ -4,13 +4,14 @@
 //! namely Windows, OS X and Linux.
 //!
 //! [`slice-deque`]: https://crates.io/crates/slice-deque
-extern crate slice_deque;
-use self::slice_deque::SliceDeque;
+extern crate slice_ring_buffer;
+use self::slice_ring_buffer::SliceRingBuffer;
 
 use std::cmp;
+use std::mem::MaybeUninit;
 
 pub struct SliceDequeBuf {
-    deque: SliceDeque<u8>,
+    deque: SliceRingBuffer<u8>,
 }
 
 /// Move-free buffer utilizing the [`slice-deque`] crate.
@@ -22,7 +23,7 @@ pub struct SliceDequeBuf {
 impl SliceDequeBuf {
     pub fn with_capacity(cap: usize) -> Self {
         SliceDequeBuf {
-            deque: SliceDeque::with_capacity(cap),
+            deque: SliceRingBuffer::with_capacity(cap),
         }
     }
 
@@ -55,7 +56,7 @@ impl SliceDequeBuf {
         &mut self.deque
     }
 
-    pub unsafe fn write_buf(&mut self) -> &mut [u8] {
+    pub unsafe fn write_buf(&mut self) -> &mut [MaybeUninit<u8>] {
         self.deque.tail_head_slice()
     }
 


### PR DESCRIPTION
slice-deque is unmaintained, "cargo test" doesn't run successfully anymore. the slice-ring-buffer fork is mentioned in https://github.com/gnzlbg/slice_deque/issues/94